### PR TITLE
Upgrade requests format due to werkzeug

### DIFF
--- a/boptestGymEnv.py
+++ b/boptestGymEnv.py
@@ -471,14 +471,14 @@ class BoptestGymEnv(gym.Env):
         
         # Initialize the building simulation
         res = requests.put('{0}/initialize'.format(self.url), 
-                           data={'start_time':self.start_time,
+                           json={'start_time':self.start_time,
                                  'warmup_period':self.warmup_period}).json()['payload']
         
         # Set simulation step
-        requests.put('{0}/step'.format(self.url), data={'step':self.step_period})
+        requests.put('{0}/step'.format(self.url), json={'step':self.step_period})
         
         # Set BOPTEST scenario
-        requests.put('{0}/scenario'.format(self.url), data=self.scenario)
+        requests.put('{0}/scenario'.format(self.url), json=self.scenario)
         
         # Initialize objective integrand
         self.objective_integrand = 0.
@@ -537,13 +537,13 @@ class BoptestGymEnv(gym.Env):
         # Assign values to inputs if any
         for i, act in enumerate(self.actions):
             # Assign value
-            u[act] = action[i]
+            u[act] = float(action[i])
             
             # Indicate that the input is active
             u[act.replace('_u','_activate')] = 1.
                 
         # Advance a BOPTEST simulation
-        res = requests.post('{0}/advance'.format(self.url), data=u).json()['payload']
+        res = requests.post('{0}/advance'.format(self.url), json=u).json()['payload']
         
         # Compute reward of this (state-action-state') tuple
         reward = self.get_reward()
@@ -717,7 +717,7 @@ class BoptestGymEnv(gym.Env):
             regr_index = res['time']-self.step_period*np.arange(1,self.regr_n+1)
             for var in self.regressive_vars:
                 res_var = requests.put('{0}/results'.format(self.url), 
-                                       data={'point_names':[var],
+                                       json={'point_names':[var],
                                              'start_time':regr_index[-1], 
                                              'final_time':regr_index[0]}).json()['payload']
                 # fill_value='extrapolate' is needed for the very few cases when
@@ -733,7 +733,7 @@ class BoptestGymEnv(gym.Env):
         # Get predictions if this is a predictive agent. 
         if self.is_predictive:
             predictions = requests.put('{0}/forecast'.format(self.url), 
-                                       data={'point_names': self.predictive_vars,
+                                       json={'point_names': self.predictive_vars,
                                              'horizon':     self.predictive_period,
                                              'interval':    self.step_period}).json()['payload']
             for var in self.predictive_vars:

--- a/examples/test_and_plot.py
+++ b/examples/test_and_plot.py
@@ -82,7 +82,7 @@ def plot_results(env, rewards, points=['reaTZon_y','reaTSetHea_y','reaTSetCoo_y'
     # point from the initialization period to don't confuse it with 
     # actions taken by the agent in a previous episode. 
     res = requests.put('{0}/results'.format(env.url), 
-                        data={'point_names':points,
+                        json={'point_names':points,
                               'start_time':env.start_time+1, 
                               'final_time':3.1536e7}).json()['payload']
 


### PR DESCRIPTION
According to [this](https://stackoverflow.com/questions/72893180/flask-restful-error-request-content-type-was-not-application-json) question, one needs to add the correct location of the input data in requests.

e.g. change 
`requests.put(url, data={'step': self.step_period})`
 to 
`requests.put(url, json={'step': self.step_period})`

Otherwise, flask would raise error: "The browser (or proxy) sent a request that this server could not understand"